### PR TITLE
Allow valid https requests in .NET Core

### DIFF
--- a/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
+++ b/Emby.Server.Implementations/HttpClientManager/HttpClientManager.cs
@@ -59,7 +59,17 @@ namespace Emby.Server.Implementations.HttpClientManager
 
             if (!_httpClients.TryGetValue(key, out var client))
             {
-                client = new HttpClient()
+                var httpClientHandler = new HttpClientHandler()
+                {
+                    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+                    {
+                        var success = errors == System.Net.Security.SslPolicyErrors.None;
+                        _logger.LogDebug("Validating certificate {Cert}. Success {1}", cert, success);
+                        return success;
+                    }
+                };
+
+                client = new HttpClient(httpClientHandler)
                 {
                     BaseAddress = new Uri(url)
                 };


### PR DESCRIPTION
ServerCertificateValidationCallback on the ServicePointManager is not supported in .NET Core and outgoing https requests will fail if the certificate is not trusted.

This adds the equivalent functionality

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
